### PR TITLE
Bugfixes

### DIFF
--- a/collection_to_headings.rb
+++ b/collection_to_headings.rb
@@ -24,6 +24,9 @@ class CollectionToHeadings
     #replace nils with 1s
     @headings_count = @headings_count.map { |count| count ? count : 1 }
 
+    #reset headings count of headings above current one
+    @headings_count.pop(@headings_count.length - heading_level - 1)
+
     #return string for the current heading level
     @headings_count.first(heading_level + 1).join('.')
   end

--- a/collection_to_headings.rb
+++ b/collection_to_headings.rb
@@ -22,7 +22,7 @@ class CollectionToHeadings
     @headings_count[heading_level] = @headings_count[heading_level].to_i + 1
 
     #replace nils with 1s
-    @headings_count = @headings_count.map { |count| count ? count : 1 }
+    @headings_count.map! { |count| count ? count : 1 }
 
     #reset headings count of headings above current one
     @headings_count.pop(@headings_count.length - heading_level - 1)


### PR DESCRIPTION
# Fixing a bug with nested headings count not being reset after starting a new parent heading
previously:
`1.
  1.1.
2.
  2.2.`
now:
`1.
  1.1.
2.
  2.1.`

# Using `map!` instead of `x = x.map`